### PR TITLE
検索時に"%"も利用可能にする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,10 @@ class ApplicationController < ActionController::Base
     redirect_to root_path, alert: "ログインしてください" unless user_signed_in?
   end
 
+  def escape_like(string)
+    string.gsub(/[\\%_]/){|m| "\\#{m}"}
+  end
+
   # Overwriting the sign_out redirect path method
   # def after_sign_out_path_for(resource_or_scope)
   #   root_path

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,11 +14,11 @@ class ItemsController < ApplicationController
 
   def search
     if params[:searchCategory].present? && params[:searchKeyword].present?
-      @resultItems = Item.where(category_id: params[:searchCategory].to_i).where('title LIKE(?)', "%#{params[:searchKeyword]}%").page(params[:page]).per(3)
+      @resultItems = Item.where(category_id: params[:searchCategory].to_i).where('title LIKE(?)', "%#{escape_like(params[:searchKeyword])}%").page(params[:page]).per(3)
     elsif params[:searchCategories].present? && params[:searchKeyword].present? == false
       @resultItems = Item.where(category_id: params[:searchCategory].to_i).page(params[:page]).per(3)
     elsif params[:searchCategories].present? == false && params[:searchKeyword].present?
-      @resultItems = Item.where('title LIKE(?)', "%#{params[:searchKeyword]}%").page(params[:page]).per(3)
+      @resultItems = Item.where('title LIKE(?)', "%#{escape_like(params[:searchKeyword])}%").page(params[:page]).per(3)
     else
       @resultItems = Item.all.page(params[:page]).per(3)
     end


### PR DESCRIPTION
# 検索時に"%"がワイルドカードとなってしまっていた為、文字列として認識されるようにする
- escape_likeメソッドを定義 @application_controller.rb
- escape_likeメソッドを適用
  例）Item.where('title LIKE(?)', "%#{escape_like(params[:searchKeyword])}%").page(params[:page]).per(3)
- %を検索の際に入力して文字列として認識されれば完了
